### PR TITLE
fix: ignore outdated ksmbd CVEs

### DIFF
--- a/internal/pkg/types/v1alpha1/data/talos.yaml
+++ b/internal/pkg/types/v1alpha1/data/talos.yaml
@@ -588,3 +588,18 @@ statements:
     status: fixed
     statusNotes: |
       CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-08-07T12:39:00Z
+    name: CVE-2023-39179
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-08-07T12:39:00Z
+    name: CVE-2023-39176
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-08-07T12:39:00Z
+    name: CVE-2023-39180
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure


### PR DESCRIPTION
They dropped unexpectedly, they were fixed upstream long time ago, but version information is incorrect in the CVEs.

They are all about ksmbd which Talos doesn't even enable.