### PR TITLE
fix: document not affected by CVEs

### DIFF
--- a/internal/pkg/types/v1alpha1/data/talos.yaml
+++ b/internal/pkg/types/v1alpha1/data/talos.yaml
@@ -318,6 +318,27 @@ statements:
       Talos does not build JFS filesystem, so the affected code is not being built.
       https://github.com/siderolabs/pkgs/blob/e2fbfb1fa1188da703b6f237cdc957ee79b41913/kernel/build/config-arm64#L8904
       https://github.com/siderolabs/pkgs/blob/e2fbfb1fa1188da703b6f237cdc957ee79b41913/kernel/build/config-amd64#L6156
+  - created: 2025-09-10T10:55:00Z
+    name: CVE-2023-3079
+    justification: vulnerable_code_not_present
+    statusNotes: |
+      Affects Google Chrome, Talos Linux does not include it.
+  - created: 2025-09-10T10:55:00Z
+    name: CVE-2024-3566
+    justification: vulnerable_code_not_present
+    statusNotes: |
+      Talos Linux itself doesn't run on Windows, but talosctl CLI tool does. 
+      However, talosctl doesn't execute processes with user input.
+  - created: 2025-09-10T10:55:00Z
+    name: CVE-2007-4998
+    justification: vulnerable_code_not_present
+    statusNotes: |
+      Talos Linux doesn't ship coreutils/busybox.
+  - created: 2025-09-10T10:55:00Z
+    name: CVE-2023-7042
+    justification: vulnerable_code_not_present
+    statusNotes: |
+      Talos Linux doesn't include wireless drivers.
 
   ### Old CVEs, not validated, but most likely addressed in mainline by the time of 6.12 release
 
@@ -608,6 +629,26 @@ statements:
       CVE from long before Linux 6.12, considered fixed by the time of disclosure
   - created: 2025-08-07T12:39:00Z
     name: CVE-2023-39180
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-09-10T11:55:00Z
+    name: CVE-2020-25672
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-09-10T11:55:00Z
+    name: CVE-1999-0656
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-09-10T11:55:00Z
+    name: CVE-2024-0193
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-09-10T11:55:00Z
+    name: CVE-2021-3669
     status: fixed
     statusNotes: |
       CVE from long before Linux 6.12, considered fixed by the time of disclosure


### PR DESCRIPTION
Most of them are outdated. The Golang CVE is only related to Windows, it won't be fixed on Go stdlib side.

```
NAME    INSTALLED  VULNERABILITY   SEVERITY  EPSS           RISK
kernel  6.16.4     CVE-2023-3079   High      0.6% (67th)    85.6   (kev)
golang  1.25.1     CVE-2024-3566   Critical  4.1% (88th)    3.8
kernel  6.16.4     CVE-2020-25672  High      1.7% (81st)    1.2
kernel  6.16.4     CVE-1999-0656   Medium    0.6% (67th)    0.3
kernel  6.16.4     CVE-2024-0193   Medium    < 0.1% (17th)  < 0.1
kernel  6.16.4     CVE-2007-4998   Medium    < 0.1% (5th)   < 0.1
kernel  6.16.4     CVE-2023-7042   Medium    < 0.1% (1st)   < 0.1
kernel  6.16.4     CVE-2021-3669   Medium    < 0.1% (0th)   < 0.1
```