### PR TITLE
fix: invalid VEX entries

### DIFF
--- a/internal/pkg/types/v1alpha1/data/talos.yaml
+++ b/internal/pkg/types/v1alpha1/data/talos.yaml
@@ -320,22 +320,26 @@ statements:
       https://github.com/siderolabs/pkgs/blob/e2fbfb1fa1188da703b6f237cdc957ee79b41913/kernel/build/config-amd64#L6156
   - created: 2025-09-10T10:55:00Z
     name: CVE-2023-3079
+    status: not_affected
     justification: vulnerable_code_not_present
     statusNotes: |
       Affects Google Chrome, Talos Linux does not include it.
   - created: 2025-09-10T10:55:00Z
     name: CVE-2024-3566
+    status: not_affected
     justification: vulnerable_code_not_present
     statusNotes: |
       Talos Linux itself doesn't run on Windows, but talosctl CLI tool does. 
       However, talosctl doesn't execute processes with user input.
   - created: 2025-09-10T10:55:00Z
     name: CVE-2007-4998
+    status: not_affected
     justification: vulnerable_code_not_present
     statusNotes: |
       Talos Linux doesn't ship coreutils/busybox.
   - created: 2025-09-10T10:55:00Z
     name: CVE-2023-7042
+    status: not_affected
     justification: vulnerable_code_not_present
     statusNotes: |
       Talos Linux doesn't include wireless drivers.

--- a/internal/pkg/types/v1alpha1/v1alpha1_test.go
+++ b/internal/pkg/types/v1alpha1/v1alpha1_test.go
@@ -10,9 +10,17 @@ import (
 
 	"github.com/openvex/go-vex/pkg/vex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/talos-vex/internal/pkg/types/v1alpha1"
 )
+
+func TestEmbeddedData_Validate(t *testing.T) {
+	data, err := v1alpha1.LoadExploitabilityData("")
+	require.NoError(t, err)
+
+	require.NoError(t, data.Validate())
+}
 
 func TestExploitabilityData_Validate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
I introduced invalid entries in the previous PR.

Add a unit-test to validate our default dataset.